### PR TITLE
Fixed composer.json to use dev-master for unit-test component, since the...

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -54,6 +54,6 @@
             "zetacomponents/base": "*"
         },
         "require-dev": {
-            "zetacomponents/unit-test": "*"
+            "zetacomponents/unit-test": "dev-master"
         }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -1,24 +1,144 @@
 {
-    "hash": "d7d156a2ed47dc191fee9a3741384cd2",
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at http://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file"
+    ],
+    "hash": "424a42b2bedcc4d50d6b7d6b30fe6f3d",
     "packages": [
         {
-            "package": "zetacomponents/base",
-            "version": "dev-master",
-            "source-reference": "d6f1d9179ebe56637b559570b0258b83b6a57554"
+            "name": "zetacomponents/base",
+            "version": "1.8",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zetacomponents/Base.git",
+                "reference": "52ca69c1de55f3fa4f595779e5bc831da7ee176c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zetacomponents/Base/zipball/52ca69c1de55f3fa4f595779e5bc831da7ee176c",
+                "reference": "52ca69c1de55f3fa4f595779e5bc831da7ee176c",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Sergey Alexeev"
+                },
+                {
+                    "name": "Sebastian Bergmann"
+                },
+                {
+                    "name": "Jan Borsodi"
+                },
+                {
+                    "name": "Raymond Bosman"
+                },
+                {
+                    "name": "Frederik Holljen"
+                },
+                {
+                    "name": "Kore Nordmann"
+                },
+                {
+                    "name": "Derick Rethans"
+                },
+                {
+                    "name": "Vadym Savchuk"
+                },
+                {
+                    "name": "Tobias Schlitt"
+                },
+                {
+                    "name": "Alexandru Stanoi"
+                }
+            ],
+            "description": "The Base package provides the basic infrastructure that all packages rely on. Therefore every component relies on this package.",
+            "homepage": "https://github.com/zetacomponents",
+            "time": "2009-12-21 12:14:16"
         }
     ],
     "packages-dev": [
         {
-            "package": "zetacomponents/unit-test",
+            "name": "zetacomponents/unit-test",
             "version": "dev-master",
-            "source-reference": "6d117e709ad5ade03a5cd395bcc80adb7fee68fc"
+            "source": {
+                "type": "git",
+                "url": "https://github.com/zetacomponents/UnitTest.git",
+                "reference": "772d6e651cb90c6de10f975b2e323df98d1e4a2c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/zetacomponents/UnitTest/zipball/772d6e651cb90c6de10f975b2e323df98d1e4a2c",
+                "reference": "772d6e651cb90c6de10f975b2e323df98d1e4a2c",
+                "shasum": ""
+            },
+            "type": "library",
+            "autoload": {
+                "classmap": [
+                    "src"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "apache2"
+            ],
+            "authors": [
+                {
+                    "name": "Sergey Alexeev"
+                },
+                {
+                    "name": "Sebastian Bergmann"
+                },
+                {
+                    "name": "Jan Borsodi"
+                },
+                {
+                    "name": "Raymond Bosman"
+                },
+                {
+                    "name": "Frederik Holljen"
+                },
+                {
+                    "name": "Kore Nordmann"
+                },
+                {
+                    "name": "Derick Rethans"
+                },
+                {
+                    "name": "Vadym Savchuk"
+                },
+                {
+                    "name": "Tobias Schlitt"
+                },
+                {
+                    "name": "Alexandru Stanoi"
+                }
+            ],
+            "description": "zetacomponents/unit-test Component",
+            "homepage": "https://github.com/zetacomponents",
+            "time": "2012-05-21 09:51:20"
         }
     ],
     "aliases": [
 
     ],
-    "minimum-stability": "dev",
-    "stability-flags": [
+    "minimum-stability": "stable",
+    "stability-flags": {
+        "zetacomponents/unit-test": 20
+    },
+    "platform": [
+
+    ],
+    "platform-dev": [
 
     ]
 }


### PR DESCRIPTION
...re is no stable release of it.

Prevents Composer complaining it can't find `zetacomponents/unit-test`.
