### PR TITLE
Changed ezcMailComposer::generateHtmlPart() to be protected instead of private

### DIFF
--- a/src/composer.php
+++ b/src/composer.php
@@ -476,7 +476,7 @@ class ezcMailComposer extends ezcMail
      *         if $fileName could not be read.
      * @return ezcMailPart
      */
-    private function generateHtmlPart()
+    protected function generateHtmlPart()
     {
         $result = false;
         if ( $this->htmlText != '' )


### PR DESCRIPTION
I wanted to extend the `automaticImageInclude` feature to external http(s) images when realizing that `ezcMailComposer::generateHtmlPart()` was private. I see no reason why it should be.
