### PR TITLE
Removed the declare() from the beginning of the files.

### DIFF
--- a/src/transports/file/file_set.php
+++ b/src/transports/file/file_set.php
@@ -1,6 +1,4 @@
 <?php
-declare(encoding="latin1");
-
 /**
  * File containing the ezcMailFileSet class
  *

--- a/src/transports/variable/var_set.php
+++ b/src/transports/variable/var_set.php
@@ -1,6 +1,4 @@
 <?php
-declare(encoding="latin1");
-
 /**
  * File containing the ezcMailVariableSet class
  *

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -1,5 +1,4 @@
 <?php
-declare(encoding="latin1");
 /**
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  * @version //autogentag//

--- a/tests/parser/parser_test.php
+++ b/tests/parser/parser_test.php
@@ -1,5 +1,4 @@
 <?php
-declare(encoding="latin1");
 /**
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  * @version //autogentag//

--- a/tests/parser/rfc2231_implementation_test.php
+++ b/tests/parser/rfc2231_implementation_test.php
@@ -1,5 +1,4 @@
 <?php
-declare(encoding="latin1");
 /**
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  * @version //autogentag//

--- a/tests/parts/text_part_test.php
+++ b/tests/parts/text_part_test.php
@@ -1,5 +1,4 @@
 <?php
-declare(encoding="latin1");
 /**
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  * @version //autogentag//

--- a/tests/tools_test.php
+++ b/tests/tools_test.php
@@ -1,5 +1,4 @@
 <?php
-declare(encoding="latin1");
 /**
  * @license http://www.apache.org/licenses/LICENSE-2.0 Apache License, Version 2.0
  * @version //autogentag//


### PR DESCRIPTION
This made sense when PHP 6 was on the way, but no more.
