### PR TITLE
Fixed bug parsing img tags in the html

### DIFF
--- a/src/composer.php
+++ b/src/composer.php
@@ -490,7 +490,7 @@ class ezcMailComposer extends ezcMail
                         src\\s*=\\s*
                             (?:
                                 (?# Match quoted attribute)
-                                ([\'"])file://(?P<quoted>[^>]+)\\1
+                                ([\'"])file://(?P<quoted>[^"]+)\\1
 
                                 (?# Match unquoted attribute, which may not contain spaces)
                             |   file://(?P<unquoted>[^>\\s]+)


### PR DESCRIPTION
Please check this change proposal, this fixes an important bug I found on my project.

The problem is that when it parses something like:

``` html
<html>
<img src="file:///namehere.jpg" width="200" />
</html>
```

It was taking the file path as 'file:///namehere.jpg" width="200" /'.

That's because the regular expression used was looking for the end of the `html<img>` tag instead of the end of the quoted text.

Now it would retrieve:

'/namehere.jpg'
