### PR TITLE
authNtlm() should return true on success

### DIFF
--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -907,6 +907,8 @@ class ezcMailSmtpTransport implements ezcMailTransport
         {
             throw new ezcMailTransportSmtpException( 'SMTP server did not allow NTLM authentication.' );
         }
+        
+        return true;
     }
 
     /**


### PR DESCRIPTION
ezcMailSmtpTransport::authNtlm() does not return true on success and is therefore not working correctly. This PR fixes this bug.
