### PR TITLE
Add TLS support to the SMTP transport

### DIFF
--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -1151,7 +1151,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         {
             while ( ( strpos( $data, self::CRLF ) === false || (string) substr( $line, 3, 1 ) !== ' ' ) && $loops < 100 )
             {
-                $line = fgets( $this->connection, 512 );
+                $line = @fgets( $this->connection, 512 );
                 $data .= $line;
                 $loops++;
             }


### PR DESCRIPTION
TLS encryption over SMTP requires that the connection is setup as unencrypted and then upgraded with the `STARTTLS` command before authentication. Currently if you set the connection type to 'tls' in the ezcMailSmtpTransport class, the connection fails with the error below. I assume this is because it is trying to speak TLS before upgrading the unencrypted SMTP connection.

```
Fatal PHP Error: Warning - stream_socket_client(): SSL operation failed with code 1. OpenSSL Error messages:
error:1408F10B:SSL routines:SSL3_GET_RECORD:wrong version number
```

This PR adds logic so if the connection type is set to 'tls', the connection is opened unencrypted and then upgraded with the `STARTTLS` command. After TLS is enabled, a second `EHLO` command is sent to obtain the available authentication methods.

I have tested this successfully with Office 365's SMTP servers; see below for a rough example.

``` php
$options = new ezcMailSmtpTransportOptions();
$options->connectionType = 'tls';
$transport = new ezcMailSmtpTransport( 'smtp.office365.com', 'email', 'password', 587, $options );
$transport->connect();
```
