### PR TITLE
Fix double folding on e-mail headers

### DIFF
--- a/src/internal/header_folder.php
+++ b/src/internal/header_folder.php
@@ -102,8 +102,8 @@ class ezcMailHeaderFolder
      */
     static public function foldAny( $text )
     {
-        // Don't fold unless we have to.
-        if ( strlen( $text ) <= self::$limit )
+        // Don't fold unless we have to (e.g. when text is already folded or it doesn't reach the limit).
+        if ( strpos( $text, ezcMailTools::lineBreak() ) !== false || strlen( $text ) <= self::$limit )
         {
             return $text;
         }

--- a/tests/header_folder_test.php
+++ b/tests/header_folder_test.php
@@ -82,6 +82,18 @@ class ezcMailHeaderFolderTest extends ezcTestCase
         $this->assertEquals( 26, strlen( $exploded[1] ) );
     }
 
+    public function testNoDoubleFold()
+    {
+        $composedAddress = ezcMailTools::composeEmailAddress(
+            new ezcMailAddress(
+                'foo@bar.com',
+                'From name ØÆÅ test test test test with a very long name which contains norwegian characters ÆØÅæøÅ',
+                'utf-8'
+            )
+        );
+        $this->assertSame( $composedAddress, ezcMailHeaderFolder::foldAny( $composedAddress ) );
+    }
+
     public static function suite()
     {
          return new PHPUnit_Framework_TestSuite( "ezcMailHeaderFolderTest" );


### PR DESCRIPTION
> Ref: https://jira.ez.no/browse/EZP-23389

When setting a from/cc/bcc header with a very long name, and using a charset different than the default one (e.g. `utf-8`), headers will be double folded: once by `ezcMailTools::composeEmailAddress()`, and once by `ezcMailHeaderFolder::foldAny()` (triggered from `ezcMailPart::generateHeaders()`).

Line length won't change, but double line break will appear, making the whole e-mail invalid.

This patch fixes it, a unit test was added.
