### PR TITLE
Fix AUTH issue with Yahoo SMTP servers

### DIFF
--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -639,7 +639,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
             }
             else
             {
-                preg_match( "/250-AUTH[= ](.*)/", $response, $matches );
+                preg_match( "/250[- ]AUTH[= ](.*)/", $response, $matches );
                 if ( count( $matches ) > 0 )
                 {
                     $methods = explode( ' ', trim( $matches[1] ) );


### PR DESCRIPTION
I was having problems getting the `ezcMailSmtpTransport` class to authenticate with Yahoo's SMTP servers. Below you can see that they omitted the dash between the status code and the auth capabilities line. I adjusted the regex slightly to accommodate this odd case and now it's working great.

```
220 smtp.mail.yahoo.com ESMTP ready
EHLO localhost
250-smtp.mail.yahoo.com
250-PIPELINING
250-SIZE 41697280
250-8 BITMIME
250 AUTH PLAIN LOGIN XOAUTH2 XYMCOOKIE
```