### PR TITLE
Fix issue with space after "=" in filename

### DIFF
--- a/src/parser/parts/file_parser.php
+++ b/src/parser/parts/file_parser.php
@@ -120,13 +120,13 @@ class ezcMailFileParser extends ezcMailPartParser
         // figure out the base filename
         // search Content-Disposition first as specified by RFC 2183
         $matches = array();
-        if ( preg_match( '/\s*filename="?([^;"]*);?/i',
+        if ( preg_match( '/\s*filename=\s?"?([^;"]*);?/i',
                         $this->headers['Content-Disposition'], $matches ) )
         {
             $fileName = trim( $matches[1], '"' );
         }
         // fallback to the name parameter in Content-Type as specified by RFC 2046 4.5.1
-        else if ( preg_match( '/\s*name="?([^;"]*);?/i',
+        else if ( preg_match( '/\s*name=\s?"?([^;"]*);?/i',
                              $this->headers['Content-Type'], $matches ) )
         {
             $fileName = trim( $matches[1], '"' );

--- a/src/parser/rfc2231_implementation.php
+++ b/src/parser/rfc2231_implementation.php
@@ -62,7 +62,7 @@ class ezcMailRfc2231Implementation
         $parameterBuffer = array();
 
         // parameters
-        if ( preg_match_all( '/\s*(\S*?)="?([^;"]*);?/i', $header, $matches, PREG_SET_ORDER ) )
+        if ( preg_match_all( '/\s*(\S*?)=\s?"?([^;"]*);?/i', $header, $matches, PREG_SET_ORDER ) )
         {
             foreach ( $matches as $parameter )
             {

--- a/tests/parser/parser_test.php
+++ b/tests/parser/parser_test.php
@@ -1765,5 +1765,30 @@ END;
         $parts = $mail->fetchParts();
         $this->assertEquals( "wir können Ihnen mitteilen, dass einer Ihrer\n", $parts[0]->text );
     }
+
+
+    /**
+     * Test for issue with extra space after "=" in header (some clients begin filename from new line and with \t prepended)
+     */
+    public function testSpaceBeforeFileName()
+    {
+        $parser = new ezcMailParser();
+        $messages = array(
+            array( "Content-Disposition: attachment; filename=\r\n\t\"=?iso-8859-1?q?Lettre=20de=20motivation=20directeur=20de=20client=E8le.doc?=\"\r\n",
+                "Lettre de motivation directeur de clientèle.doc" ),
+
+        );
+
+        foreach ( $messages as $msg )
+        {
+            $set = new ezcMailVariableSet( $msg[0] );
+            $mail = $parser->parseMail( $set );
+            $mail = $mail[0];
+
+            // check the body
+            $this->assertEquals( $msg[1], $mail->contentDisposition->displayFileName );
+        }
+    }
+
 }
 ?>


### PR DESCRIPTION
Sometimes clients form Content-Disposition and Content-Type headers like this:
```
Content-Disposition: attachment; filename=
	"=?koi8-r?........
```
So there is \r\n\t between = and " that transforms to space and that leads to wrong parsing

![filename bug](https://cloud.githubusercontent.com/assets/1073706/8159190/ec7b7692-136c-11e5-836e-94fbd349f84b.png)


