### PR TITLE
Custom line endings support for POP3

### DIFF
--- a/src/transports/transport_connection.php
+++ b/src/transports/transport_connection.php
@@ -220,7 +220,7 @@ class ezcMailTransportConnection
         if ( is_resource( $this->connection ) )
         {
             // in case there is a problem with the connection fgets() returns false
-            while ( strpos( $data, self::CRLF ) === false )
+            while ( strpos( $data, ezcMailTools::lineBreak() ) === false )
             {
                 $line = fgets( $this->connection, 512 );
 


### PR DESCRIPTION
I got issue with https://mailtrap.io/ and POP3: messages come with "\n" as EOL. I see, that support of custom line endings is already available for SMTP. I did the same for POP3.

It works for me now, but I'm bit confused. Messages are displayed normal in OS X Mail and Mailtrap interface, but as I can see in the standard, only CRLF is allowed.
