### PR TITLE
Extends the possible Parts that can be handled in ezcMail::walkParts

### DIFF
--- a/src/mail.php
+++ b/src/mail.php
@@ -518,6 +518,8 @@ class ezcMail extends ezcMailPart
 
             case 'ezcMailText':
             case 'ezcMailFile':
+            case 'ezcMailVirtualFile':
+            case 'ezcMailStreamFile':
             case 'ezcMailDeliveryStatus':
                 if ( empty( $context->filter ) || in_array( $className, $context->filter ) )
                 {

--- a/tests/parser/walk_context_test.php
+++ b/tests/parser/walk_context_test.php
@@ -88,6 +88,45 @@ class ezcMailPartWalkContextTest extends ezcTestCase
         $this->assertEquals( false, isset( $context->no_such_property ) );
     }
 
+    public function testWalkPartsForVirtualFile()
+    {
+        // create mail instance
+        $mail = new ezcMailComposer();
+        $mail->addAttachment("file.txt", "content");
+        $mail->build();
+        // create the testing context
+        $context = new ezcMailPartWalkContext(
+            function ($ctx, $part) {
+                $this->assertInstanceOf('ezcMailVirtualFile', $part);
+            }
+        );
+        $context->filter = ['ezcMailVirtualFile'];
+        // test it
+        $mail->walkParts($context, $mail);
+    }
+
+    public function testWalkPartsForStreamFile()
+    {
+        // create a temporary file
+        $tmpFile = tempnam(sys_get_temp_dir(), "stream");
+        file_put_contents($tmpFile, "content");
+        // create mail instance
+        $mail = new ezcMailComposer();
+        $mail->addAttachment($tmpFile);
+        $mail->build();
+        // create the testing context
+        $context = new ezcMailPartWalkContext(
+            function ($ctx, $part) {
+                $this->assertInstanceOf('ezcMailStreamFile', $part);
+            }
+        );
+        $context->filter = ['ezcMailStreamFile'];
+        // test it
+        $mail->walkParts($context, $mail);
+        // remove the temporary file
+        @unlink($tmpFile);
+    }
+
     public static function suite()
     {
          return new PHPUnit_Framework_TestSuite( "ezcMailPartWalkContextTest" );


### PR DESCRIPTION
This PR extends the ezcMail::walkParts method with the ability to handle ezcMailVirtualFile and ezcMailStreamFile instances.

This allows e.g. to extract attachments of ezcMail instances where one of the previously named classes were used.