### PR TITLE
Fixed UID fetchFromOffset in imap_transport.php

### DIFF
--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -1622,7 +1622,8 @@ class ezcMailImapTransport
             }
 
             $range = array();
-            for ( $i = $ids[$offset]; $i < min( $count, count( $messages ) ); $i++ )
+            $base = $ids[$offset];
+            for ( $i = $base; $i < min( $count, count( $messages ) ) + $base; $i++ )
             {
                 $range[] = $messages[$i];
             }


### PR DESCRIPTION
Fixed an issue where we would not fetch the next N messages when using UID IMAP transport option. Code should start at $offset (as before) but the index of $offset should be added to the iterator to select the next N messages in the range.
