### PR TITLE
Update preg_match on STARTTLS check

### DIFF
--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -621,7 +621,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         // setup TLS connection before continuing with AUTH
         if ( $this->options->connectionType == 'tls' )
         {
-            if ( !preg_match( "/250-STARTTLS/", $response) )
+            if ( !preg_match( "/250[- ]STARTTLS/", $response) )
             {
                 throw new ezcMailTransportSmtpException( 'SMTP server does not accept the STARTTLS command.' );
             }


### PR DESCRIPTION
Some servers appear to return "250 STARTTLS" instead of "250-STARTTLS". I have changed the condition to account for that.