### PR TITLE
Fixed empty filename in file_parser

### DIFF
--- a/src/parser/parts/file_parser.php
+++ b/src/parser/parts/file_parser.php
@@ -136,6 +136,10 @@ class ezcMailFileParser extends ezcMailPartParser
             $fileName = "filename";
         }
 
+        if (empty($fileName)) {  // $fileName can be empty in reality, then the openFile() call fails because it's trying to open a directory with fopen
+            $fileName = "filename";
+        }
+
         // clean file name (replace unsafe characters with underscores)
         $fileName = strtr( $fileName, "/\\\0\"|?*<:;>+[]", '______________' );
 

--- a/src/parser/parts/file_parser.php
+++ b/src/parser/parts/file_parser.php
@@ -136,7 +136,8 @@ class ezcMailFileParser extends ezcMailPartParser
             $fileName = "filename";
         }
 
-        if (empty($fileName)) {  // $fileName can be empty in reality, then the openFile() call fails because it's trying to open a directory with fopen
+        if ( empty( $fileName ) )  // $fileName can be empty in reality, then the openFile() call fails because it's trying to open a directory with fopen
+        {
             $fileName = "filename";
         }
 

--- a/tests/parser/data/various/attachment_without_filename.mail
+++ b/tests/parser/data/various/attachment_without_filename.mail
@@ -1,0 +1,55 @@
+Return-Path: <as@ez.no>
+X-Original-To: as@ez.no
+Delivered-To: as@mail.ez.no
+Received: from smtp.ez.no (blackboy.ez.no [194.248.150.22])
+	by mta1.ez.no (Postfix) with ESMTP id 99508362508
+	for <as@ez.no>; Fri, 23 Nov 2007 13:29:23 +0100 (CET)
+Received: from [10.0.2.184] (popeye.ez.no [85.19.74.66])
+	by smtp.ez.no (Postfix) with ESMTP id D611AAB54C
+	for <as@ez.no>; Fri, 23 Nov 2007 13:26:40 +0100 (CET)
+Message-ID: <4746C7D6.5010203@ez.no>
+Date: Fri, 23 Nov 2007 13:30:14 +0100
+From: Alexandru Stanoi <as@ez.no>
+User-Agent: Thunderbird 1.5.0.12 (X11/20070604)
+MIME-Version: 1.0
+To: Alexandru Stanoi <as@ez.no>
+Subject: TEST: HTML attachment
+Content-Type: multipart/mixed;
+ boundary="1234567890"
+
+
+--1234567890
+Content-Type: text/html; charset=iso-8859-1
+Content-Transfer-Encoding: 7bit
+
+<html>
+<body marginwidth="0" marginheight="0" leftmargin="0" topmargin="0"  
+bgcolor="#FFFFFF">
+<table border="0" width="640" cellspacing="0" cellpadding="0"><tr><td>
+<img src="cid:cam_data/photo067" alt="cam_data/photo067.jpg"><br><br>
+</td></tr></table>
+</body></html>
+
+--1234567890
+Content-Type: image/jpeg; name=""
+Content-Transfer-Encoding: base64
+Content-ID: <cam_data/photo067>
+Content-Disposition: attachment; filename=""
+
+/9j/4AAQSkZJRgABAgEAkACQAAD/ 
+2wCEAAwICQoJBwwKCQoNDAwOER0TERAQESQZGxUdKiUsLCkl
+KSgvNEM5LzE/ 
+MigpOk87P0VHS0xLLThSWFFJV0NJS0gBDA0NEQ8RIhMTIkgwKTBISEhISEhISEhI
+SEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISEhISP/ 
+AABEIAPABQAMBIQACEQED
+EQH/3QAEABT/ 
+xAGiAAABBQEBAQEBAQAAAAAAAAAAAQIDBAUGBwgJCgsQAAIBAwMCBAMFBQQEAAAB
+fQECAwAEEQUSITFBBhNRYQcicRQygZGhCCNCscEVUtHwJDNicoIJChYXGBkaJSYnKCkqNDU2Nzg5
+OkNERUZHSElKU1RVVldYWVpjZGVmZ2hpanN0dXZ3eHl6g4SFhoeIiYqSk5SVlpeYmZqio6Slpqeo
+qaqys7S1tre4ubrCw8TFxsfIycrS09TV1tfY2drh4uPk5ebn6Onq8fLz9PX29/ 
+j5+gEAAwEBAQEB
+AQEBAQAAAAAAAAECAwQFBgcICQoLEQACAQIEBAMEBwUEBAABAncAAQIDEQQFITEGEkFRB2FxEyIy
+gQgUQpGhscEJIzNS8BVictEKFiQ04SXxFxgZGiYnKCkqNTY3ODk6Q0RFRkdISUpTVFVWV1hZWmNk
+ZWZnaG 
+
+--1234567890--

--- a/tests/parser/parser_test.php
+++ b/tests/parser/parser_test.php
@@ -1504,6 +1504,17 @@ END;
         $this->assertEquals( 'cam_data_photo067.jpg', basename( $parts[1]->fileName ) );
     }
 
+    public function testAttachmentWithoutFilename()
+    {
+        $parser = new ezcMailParser();
+        $set = new SingleFileSet( 'various/attachment_without_filename.mail' );
+        $mail = $parser->parseMail( $set );
+        $this->assertEquals( 1, count( $mail ) );
+        $mail = $mail[0];
+        $parts = $mail->body->getParts();
+        $this->assertEquals( 'filename', basename( $parts[1]->fileName ) );
+    }
+
     /**
      * Test for bug #12844.
      */


### PR DESCRIPTION
Fixes the following Warning:
PHP Warning: fopen(/tmp/15941-1/): failed to open stream: Is a directory in ..../ezcomponents/Mail/src/parser/parts/file_parser.php on line 154
There seem to be mails out there with an empty filename...