### PR TITLE
Fix GMail flag response in ezcMailImapTransport::fetchFlags()

### DIFF
--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -2052,6 +2052,8 @@ class ezcMailImapTransport
                         $parts = explode( ' ', $matches[1] );
                         $flags[intval( $matches[2] )] = $parts;
                     }
+
+                    // The second regex here is to handle edge cases where a mail server like gmail returns the FETCH response in a different order than normal
                     else
                     {
                         preg_match( '/\*\s.*\sFETCH\s\(UID\s(.*)\sFLAGS \((.*)\)\)/U', $response, $matches );

--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -2047,9 +2047,17 @@ class ezcMailImapTransport
             {
                 if ( $this->options->uidReferencing )
                 {
-                    preg_match( '/\*\s.*\sFETCH\s\(FLAGS \((.*)\)\sUID\s(.*)\)/U', $response, $matches );
-                    $parts = explode( ' ', $matches[1] );
-                    $flags[intval( $matches[2] )] = $parts;
+                    if ( preg_match( '/\*\s.*\sFETCH\s\(FLAGS \((.*)\)\sUID\s(.*)\)/U', $response, $matches ) )
+                    {
+                        $parts = explode( ' ', $matches[1] );
+                        $flags[intval( $matches[2] )] = $parts;
+                    }
+                    else
+                    {
+                        preg_match( '/\*\s.*\sFETCH\s\(UID\s(.*)\sFLAGS \((.*)\)\)/U', $response, $matches );
+                        $parts = explode( ' ', $matches[2] );
+                        $flags[intval( $matches[1] )] = $parts;
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
Fixed an issue where ezcMailImapTransport::fetchFlags() would not return the flags for a GMail account.  This problem is described at https://github.com/zetacomponents/Mail/issues/48

I did not provide a test case because it appears that the current testcase for this component is an integration test that uses a private mail server, and I could not figure out a way to write an future-proofed integration test against a GMail account, given Google's propensity for shutting down perceived abuse.