### PR TITLE
Update STARTTLS parsing to allow 250 STARTTLS

### DIFF
--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -621,7 +621,7 @@ class ezcMailSmtpTransport implements ezcMailTransport
         // setup TLS connection before continuing with AUTH
         if ( $this->options->connectionType == 'tls' )
         {
-            if ( !preg_match( "/250-STARTTLS/", $response) )
+            if ( !preg_match( "/250[- ]STARTTLS/", $response) )
             {
                 throw new ezcMailTransportSmtpException( 'SMTP server does not accept the STARTTLS command.' );
             }


### PR DESCRIPTION
I found an issue where the `ezcMailSmtpTransport` class was unable to use `STARTTLS` with certain smtp servers. Below you can see an example where a server omitted the dash between the status code and the starttls capability. I updated the validation regex to handle this case.

```
❯ telnet smtp.1and1.com 587
EHLO client.example.com
250-perfora.net Hello client.example.com [98.209.16.224]
250-SIZE 69920427
250-AUTH LOGIN PLAIN
250 STARTTLS
STARTTLS
220 OK
```