### PR TITLE
Mitigates against possible PHP Object Injection exploits

### DIFF
--- a/src/parser/parts/file_parser.php
+++ b/src/parser/parts/file_parser.php
@@ -189,7 +189,7 @@ class ezcMailFileParser extends ezcMailPartParser
     {
         // finish() was not called. The mail is completely broken.
         // we will clean up the mess
-        if ( $this->fp !== null )
+        if ( is_resource( $this->fp ) )
         {
             fclose( $this->fp );
             $this->fp = null;


### PR DESCRIPTION
This simple change to check if the file pointer is a resource instead of !== null makes it impossible to use the ezcMailFileParser in a PHP Object Injection exploit, as file pointer resources cannot be unserialized.

Before this change it is possible to craft a string that would unserialize to an object with a non-null ->fp member variable (fclose() will only trigger a E_WARNING for that) if ->fileName contains a valid path to a file, it will remove that file (subject to file permissions of course)