### PR TITLE
Fixed issue #58: Restrict the set of characters that can be used for the ezcMail returnPath property.

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -3,6 +3,9 @@
 
 - Added support for XOAUTH2 authentication method for SMTP transport (Ian
   Berry).
+- Fixed issue #58: Restrict the set of characters that can be used as the email
+  address for the ezcMail returnPath property. (CVE-2017-15806, reported by
+  "Kay")
 
 
 1.8.1 - Tuesday 04 November 2014

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -3,6 +3,7 @@
     <testsuites>
         <testsuite name="Zeta Components Mail">
             <directory suffix="_test.php">./tests</directory>
+            <exclude>./tests/transports</exclude>
         </testsuite>
     </testsuites>
 

--- a/src/mail.php
+++ b/src/mail.php
@@ -89,7 +89,11 @@
  *                                       The date/time of when the message was
  *                                       sent as Unix Timestamp.
  * @property ezcMailAddress        $returnPath Contains the Return-Path address as an
- *                                             ezcMailAddress object.
+ *                                             ezcMailAddress object. The email
+ *                                             address embedded in the
+ *                                             ezcMailAddress object may only
+ *                                             contain letters from the
+ *                                             RETURN_PATH_CHARS set.
  * @property ezcMailOptions $options
  *           Options for generating mail. See {@link ezcMailOptions}.
  *
@@ -125,6 +129,11 @@ class ezcMail extends ezcMailPart
      * Base 64 encoding.
      */
     const BASE64 = "base64";
+
+    /**
+     * Characters allowed in the returnPath address
+     */
+    const RETURN_PATH_CHARS = 'A-Za-z0-9_.@=/+{}#~-';
 
     /**
      * Holds the options for this class.
@@ -173,8 +182,19 @@ class ezcMail extends ezcMailPart
     {
         switch ( $name )
         {
-            case 'from':
             case 'returnPath':
+                if ( $value !== null && !$value instanceof ezcMailAddress )
+                {
+                    throw new ezcBaseValueException( $name, $value, 'ezcMailAddress or null' );
+                }
+                if ( preg_replace( '([' . self::RETURN_PATH_CHARS . '])', '', $value->email ) != '' )
+                {
+                    throw new ezcBaseValueException( $name, $value->email, 'the characters \'' . self::RETURN_PATH_CHARS . '\'' );
+                }
+                $this->properties[$name] = $value;
+                break;
+
+            case 'from':
                 if ( $value !== null && !$value instanceof ezcMailAddress )
                 {
                     throw new ezcBaseValueException( $name, $value, 'ezcMailAddress or null' );

--- a/src/transports/mta/mta_transport.php
+++ b/src/transports/mta/mta_transport.php
@@ -68,7 +68,8 @@ class ezcMailMtaTransport implements ezcMailTransport
         $additionalParameters = "";
         if ( isset( $mail->returnPath ) )
         {
-            $additionalParameters = "-f{$mail->returnPath->email}";
+            $sanitized = preg_replace( '([^' . ezcMail::RETURN_PATH_CHARS . '])', '', $mail->returnPath->email );
+            $additionalParameters = "-f{$sanitized}";
         }
         $success = mail( ezcMailTools::composeEmailAddresses( $mail->to ),
                          $mail->getHeader( 'Subject' ), $mail->generateBody(), $headers, $additionalParameters );

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -494,6 +494,26 @@ class ezcMailTest extends ezcTestCase
         $this->assertEquals( false, isset( $mail->no_such_property ) );
     }
 
+    public function testValidReturnPathChars()
+    {
+        $mail = new ezcMail();
+        $mail->returnPath = new ezcMailAddress( 'nospam@example.com' );
+        $this->assertEquals( 'nospam@example.com', $mail->returnPath->email );
+    }
+
+    public function testInvalidReturnPathChars()
+    {
+        $mail = new ezcMail();
+        try {
+            $mail->returnPath = new ezcMailAddress( 'with space@example.com' );
+            $this->fail( 'Expected exception not thrown' );
+        }
+        catch ( ezcBaseValueException $e )
+        {
+            $this->assertEquals( "The value 'with space@example.com' that you were trying to assign to setting 'returnPath' is invalid. Allowed values are: the characters '" . ezcMail::RETURN_PATH_CHARS . "'.", $e->getMessage() );
+        }
+    }
+
     public static function suite()
     {
          return new PHPUnit_Framework_TestSuite( "ezcMailTest" );


### PR DESCRIPTION
This issue is documented as CVE-2017-15806, and should be classified as "Low
Risk".

It is indeed possible to pass arbitrary parameters to the "sendmail" binary
when setting the returnPath property of ezcMail when using the
ezcMailMtaTransport. In some situations, it is possible to use an e-mail
address that contains -X/path/to/wwwroot/file.php" to write a file to the file
system, that can then be accessed and run through domainname/file.php.

This is only possible if *all* of these conditions are true:

- you use the ezcMailMtaTransport
- your "sendmail" binary allows the -X flag to be set, which is not the case
  for exim4 and postfix, as they don't support that argument
- your wwwroot is writable by the user your webserver is running at
- the input to use for the ezcMailAddress that is assigned to the returnPath
  property is not filtered