### PR TITLE
Fix error when trying to access email from null

### DIFF
--- a/src/mail.php
+++ b/src/mail.php
@@ -187,7 +187,7 @@ class ezcMail extends ezcMailPart
                 {
                     throw new ezcBaseValueException( $name, $value, 'ezcMailAddress or null' );
                 }
-                if ( preg_replace( '([' . self::RETURN_PATH_CHARS . '])', '', $value->email ) != '' )
+                if ( $value !== null && preg_replace( '([' . self::RETURN_PATH_CHARS . '])', '', $value->email ) != '' )
                 {
                     throw new ezcBaseValueException( $name, $value->email, 'the characters \'' . self::RETURN_PATH_CHARS . '\'' );
                 }

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -501,6 +501,13 @@ class ezcMailTest extends ezcTestCase
         $this->assertEquals( 'nospam@example.com', $mail->returnPath->email );
     }
 
+    public function testEmptyReturnPath()
+    {
+        $mail = new ezcMail();
+        $mail->returnPath = null;
+        $this->assertNull( $mail->returnPath );
+    }
+
     public function testInvalidReturnPathChars()
     {
         $mail = new ezcMail();


### PR DESCRIPTION
Since #59 was merged we receive the following error

```
Trying to get property of non-object
```

This fixes the problem because the value can be null

//cc @derickr 