### PR TITLE
fixed two implode() calls (wrong parameter order)

### DIFF
--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -1089,7 +1089,7 @@ class ezcMailImapTransport
         }
 
         $sizes = array();
-        $ids = implode( $messages, ',' );
+        $ids = implode( ',', $messages );
 
         $tag = $this->getNextTag();
         $this->connection->sendData( "{$tag} {$uid}FETCH {$ids} (RFC822.SIZE)" );
@@ -2035,7 +2035,7 @@ class ezcMailImapTransport
         }
 
         $flags = array();
-        $ids = implode( $messages, ',' );
+        $ids = implode( ',', $messages );
 
         $tag = $this->getNextTag();
         $this->connection->sendData( "{$tag} {$uid}FETCH {$ids} (FLAGS)" );


### PR DESCRIPTION
implode() wants to have $glue first, then $pieces: http://php.net/implode

The note on that page says:
implode() can, for historical reasons, accept its parameters in either order. For consistency with explode(), however, it may be less confusing to use the documented order of arguments.

 So it was not really a bug, only a bit ugly :-)