### PR TITLE
Get from server the host name to put it as sender host.

### DIFF
--- a/src/transports/smtp/smtp_transport.php
+++ b/src/transports/smtp/smtp_transport.php
@@ -316,7 +316,8 @@ class ezcMailSmtpTransport implements ezcMailTransport
         $this->doAuthenticate = $user != '' ? true : false;
 
         $this->status = self::STATUS_NOT_CONNECTED;
-        $this->senderHost = 'localhost';
+        $hostName = gethostname();
+        $this->senderHost = ( $hostName === false ) ? 'localhost' : $hostName;
     }
 
     /**


### PR DESCRIPTION
Some servers reject messages when the sender host is set to localhost.