### PR TITLE
Issue68: Fix invalid regex for PHP 7.3

### DIFF
--- a/src/parser/interfaces/part_parser.php
+++ b/src/parser/interfaces/part_parser.php
@@ -225,7 +225,7 @@ abstract class ezcMailPartParser
     protected function parseHeader( $line, ezcMailHeadersHolder $headers )
     {
         $matches = array();
-        preg_match_all( "/^([\w-_]*):\s?(.*)/", $line, $matches, PREG_SET_ORDER );
+        preg_match_all( "/^([\w\-_]*):\s?(.*)/", $line, $matches, PREG_SET_ORDER );
         if ( count( $matches ) > 0 )
         {
             if ( !in_array( strtolower( $matches[0][1] ), self::$uniqueHeaders ) )

--- a/src/parser/parts/delivery_status_parser.php
+++ b/src/parser/parts/delivery_status_parser.php
@@ -90,7 +90,7 @@ class ezcMailDeliveryStatusParser extends ezcMailPartParser
     protected function parseHeader( $line, ezcMailHeadersHolder $headers )
     {
         $matches = array();
-        preg_match_all( "/^([\w-_]*):\s?(.*)/", $line, $matches, PREG_SET_ORDER );
+        preg_match_all( "/^([\w\-_]*):\s?(.*)/", $line, $matches, PREG_SET_ORDER );
         if ( count( $matches ) > 0 )
         {
             $this->lastParsedHeader = $matches[0][1];


### PR DESCRIPTION
Escape '-' character in character ranges in regex to be compatible with PHP 7.3.