### PR TITLE
fixes #51 User names and passwords can contain spaces.

### DIFF
--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -543,7 +543,9 @@ class ezcMailImapTransport
         }
 
         $tag = $this->getNextTag();
-        $this->connection->sendData( "{$tag} LOGIN {$user} {$password}" );
+        $user = addcslashes($user, '\"');
+        $password = addcslashes($password, '\"');
+        $this->connection->sendData( "{$tag} LOGIN \"{$user}\" \"{$password}\"" );
         $response = trim( $this->connection->getLine() );
         // hack for gmail, to fix issue #15837: imap.google.com (google gmail) changed IMAP response
         if ( $this->serverType === self::SERVER_GIMAP && strpos( $response, "* CAPABILITY" ) === 0 )


### PR DESCRIPTION
Passwords need to be quoted since they may contain spaces (and any double-quote or backslash need to be escaped with backslash).

Note: I have a feeling this library doesn't correctly handle non-ASCII characters in password.. but I didn't try to tackle that in this PR :)