### PR TITLE
Prevent returning undefined variable

### DIFF
--- a/src/transports/imap/imap_set.php
+++ b/src/transports/imap/imap_set.php
@@ -221,8 +221,8 @@ class ezcMailImapSet implements ezcMailParserSet
                     }
                     return $data;
                 }
+                return $data;
             }
-            return $data;
         }
         return null;
     }


### PR DESCRIPTION
### What does it do?
The `$data` variable might be undefined outside if this `if`, only return it when it has been defined.