### PR TITLE
Fix PHP Syntax Errors

### DIFF
--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -564,7 +564,7 @@ class ezcMailImapTransport
      */
     public function authenticate( $user, $password, $method = ezcMailImapTransport::AUTH_LOGIN )
     {
-        if ( !in_array($method, self::getSupportedAuthMethods() )
+        if ( !in_array($method, self::getSupportedAuthMethods() ) )
         {
             throw new ezcMailTransportException( "Unsupported Authentication method used" );
         }
@@ -573,7 +573,7 @@ class ezcMailImapTransport
             throw new ezcMailTransportException( "Tried to authenticate when there was no connection or when already authenticated." );
         }
 
-        switch ( $method ) {
+        switch ( $method )
         {
             case self::AUTH_LOGIN:
                 $this->sendLogin( $user, $password );


### PR DESCRIPTION
@derickr this fixes a couple of syntax errors highlighted by a fellow contributor https://github.com/civicrm/civicrm-core/pull/16307#issuecomment-575426192

Suggest dropping a 1.9.1