### PR TITLE
Update regex for return path to allow for a single quote to be includ…

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit bootstrap="./tests/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="false">
+<phpunit bootstrap="./tests/bootstrap.php" colors="true" beStrictAboutTestsThatDoNotTestAnything="false" cacheResult="false">
     <testsuites>
         <testsuite name="Zeta Components Mail">
             <directory suffix="_test.php">./tests</directory>

--- a/src/mail.php
+++ b/src/mail.php
@@ -133,7 +133,7 @@ class ezcMail extends ezcMailPart
     /**
      * Characters allowed in the returnPath address
      */
-    const RETURN_PATH_CHARS = 'A-Za-z0-9_.@=/+{}#~-';
+    const RETURN_PATH_CHARS = 'A-Za-z0-9_.@=/+{}#~\-\'';
 
     /**
      * Holds the options for this class.

--- a/tests/composer_test.php
+++ b/tests/composer_test.php
@@ -33,7 +33,7 @@ class ezcMailComposerTest extends ezcTestCase
 {
     private $mail;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
         $this->mail = new ezcMailComposer();
 	}

--- a/tests/interfaces/part_test.php
+++ b/tests/interfaces/part_test.php
@@ -46,7 +46,7 @@ class ezcMailPartTest extends ezcTestCase
 {
     private $part;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
         $this->part = new MailPartTest();
 	}

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -15,7 +15,7 @@ class ezcMailTest extends ezcTestCase
 {
     private $mail;
 
-    protected function setUp()
+    protected function setUp(): void
     {
         $this->mail = new ezcMail();
     }
@@ -505,6 +505,13 @@ class ezcMailTest extends ezcTestCase
         $mail = new ezcMail();
         $mail->returnPath = null;
         $this->assertNull( $mail->returnPath );
+    }
+
+    public function testSingleQuoteReturnPath()
+    {
+        $mail = new ezcMail();
+        $mail->returnPath = new ezcMailAddress( 'TestEmailWith\'singlequote@example.com' );
+        $this->assertEquals( 'TestEmailWith\'singlequote@example.com', $mail->returnPath->email );
     }
 
     public function testInvalidReturnPathChars()

--- a/tests/parts/multipart_test.php
+++ b/tests/parts/multipart_test.php
@@ -55,7 +55,7 @@ class ezcMailMultipartTest extends ezcTestCase
 {
     private $multipart;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
         $this->multipart = new TestMultipart();
 	}

--- a/tests/parts/text_part_test.php
+++ b/tests/parts/text_part_test.php
@@ -16,7 +16,7 @@ class ezcMailTextTest extends ezcTestCase
 {
     private $part;
 
-	protected function setUp()
+	protected function setUp(): void
 	{
         $this->part = new ezcMailText( "dummy" );
 	}


### PR DESCRIPTION
…ed in the email as permitted by the RFC

This updates the regex to permit single quotes to be within the local part of the return path as per RFC-3696 point 3 https://www.rfc-editor.org/rfc/rfc3696.txt

This also updates the phpunit code to work with phpunit8 standards