### PR TITLE
Use filter_var with FILTER_VALIDATE_EMAIL to validate e-mail addresse…

### DIFF
--- a/src/mail.php
+++ b/src/mail.php
@@ -93,7 +93,7 @@
  *                                             address embedded in the
  *                                             ezcMailAddress object may only
  *                                             contain letters from the
- *                                             RETURN_PATH_CHARS set.
+ *                                             function filter_var FILTER_VALIDATE_EMAIL.
  * @property ezcMailOptions $options
  *           Options for generating mail. See {@link ezcMailOptions}.
  *
@@ -129,11 +129,6 @@ class ezcMail extends ezcMailPart
      * Base 64 encoding.
      */
     const BASE64 = "base64";
-
-    /**
-     * Characters allowed in the returnPath address
-     */
-    const RETURN_PATH_CHARS = 'A-Za-z0-9_.@=/+{}#~\-\'';
 
     /**
      * Holds the options for this class.
@@ -187,9 +182,9 @@ class ezcMail extends ezcMailPart
                 {
                     throw new ezcBaseValueException( $name, $value, 'ezcMailAddress or null' );
                 }
-                if ( $value !== null && preg_replace( '([' . self::RETURN_PATH_CHARS . '])', '', $value->email ) != '' )
+                if ( $value !== null && !filter_var( $value->email, FILTER_VALIDATE_EMAIL ) )
                 {
-                    throw new ezcBaseValueException( $name, $value->email, 'the characters \'' . self::RETURN_PATH_CHARS . '\'' );
+                    throw new ezcBaseValueException( $name, $value->email, 'invalid email address or null' );
                 }
                 $this->properties[$name] = $value;
                 break;

--- a/src/transports/mta/mta_transport.php
+++ b/src/transports/mta/mta_transport.php
@@ -40,6 +40,11 @@
 class ezcMailMtaTransport implements ezcMailTransport
 {
     /**
+     * Characters allowed in the returnPath address
+     */
+    const RETURN_PATH_CHARS = 'A-Za-z0-9_.@=/+{}#~\-\'';
+
+    /**
      * Constructs a new ezcMailMtaTransport.
      */
     public function __construct(  )
@@ -68,7 +73,7 @@ class ezcMailMtaTransport implements ezcMailTransport
         $additionalParameters = "";
         if ( isset( $mail->returnPath ) )
         {
-            $sanitized = preg_replace( '([^' . ezcMail::RETURN_PATH_CHARS . '])', '', $mail->returnPath->email );
+            $sanitized = preg_replace( '([^' . self::RETURN_PATH_CHARS . '])', '', $mail->returnPath->email );
             $additionalParameters = "-f{$sanitized}";
         }
         $success = mail( ezcMailTools::composeEmailAddresses( $mail->to ),

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -523,7 +523,7 @@ class ezcMailTest extends ezcTestCase
         }
         catch ( ezcBaseValueException $e )
         {
-            $this->assertEquals( "The value 'with space@example.com' that you were trying to assign to setting 'returnPath' is invalid. Allowed values are: the characters '" . ezcMail::RETURN_PATH_CHARS . "'.", $e->getMessage() );
+            $this->assertEquals( "The value 'with space@example.com' that you were trying to assign to setting 'returnPath' is invalid.", $e->getMessage() );
         }
     }
 


### PR DESCRIPTION
…s against the syntax in RFC 822 RETURN_PATH_CHARS. Use FILTER_SANITIZE_EMAIL to sanitising email.

This is an alternate version of #86 which replaces the regex approach with the built-in PHP function to provide increased coverage for the local-part variations which are valid.

Some background reading:
https://www.php.net/manual/en/filter.filters.validate.php

RFCs:
https://datatracker.ietf.org/doc/html/rfc822 (1982)
https://datatracker.ietf.org/doc/html/rfc2822 (2001)
https://datatracker.ietf.org/doc/html/rfc5322 (2008)

Good discussion about use of FILTER_VALIDATE_EMAIL:
https://bugs.php.net/bug.php?id=43402

And another BSD licensed alternative:
http://www.dominicsayers.com/isemail/
https://github.com/dominicsayers/isemail

Agileware Ref: CIVICRM-1601