### PR TITLE
Php 8 compatibility

### DIFF
--- a/src/transports/imap/imap_transport.php
+++ b/src/transports/imap/imap_transport.php
@@ -1854,7 +1854,7 @@ class ezcMailImapTransport
      * @param bool $reverse
      * @return ezcMailImapSet
      */
-    public function sortFromOffset( $offset, $count = 0, $sortCriteria, $reverse = false )
+    public function sortFromOffset( $offset, $count, $sortCriteria, $reverse = false )
     {
         if ( $count < 0 )
         {


### PR DESCRIPTION
On php 8 there is the following notice

Deprecated function: Required parameter $sortCriteria follows optional parameter $count in include() (line571 in /var/www/civi_live/vendor/composer/ClassLoader.php)

It is also meaningless for count to be optional as it must be provided in order to provide ` $sortCriteria`