### PR TITLE
Fixed #90: Allow for longer email address in Return-Path

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,10 @@
+1.9.6 - XXX XX XXX 2023
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+- Fixed #90: Allow longer email addresses than the SMTP spec allows for
+  Return-Path.
+
+
 1.9.5 - Wednesday 06 September 2023
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 

--- a/src/mail.php
+++ b/src/mail.php
@@ -162,6 +162,15 @@ class ezcMail extends ezcMailPart
         $this->options = $options;
     }
 
+	private function validateReturnPath( $returnPath )
+	{
+		$regex = "/^(?!(?:(?:\\x22?\\x5C[\\x00-\\x7E]\\x22?)|(?:\\x22?[^\\x5C\\x22]\\x22?)){255,})(?!(?:(?:\\x22?\\x5C[\\x00-\\x7E]\\x22?)|(?:\\x22?[^\\x5C\\x22]\\x22?)){125,}@)(?:(?:[\\x21\\x23-\\x27\\x2A\\x2B\\x2D\\x2F-\\x39\\x3D\\x3F\\x5E-\\x7E]+)|(?:\\x22(?:[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x21\\x23-\\x5B\\x5D-\\x7F]|(?:\\x5C[\\x00-\\x7F]))*\\x22))(?:\\.(?:(?:[\\x21\\x23-\\x27\\x2A\\x2B\\x2D\\x2F-\\x39\\x3D\\x3F\\x5E-\\x7E]+)|(?:\\x22(?:[\\x01-\\x08\\x0B\\x0C\\x0E-\\x1F\\x21\\x23-\\x5B\\x5D-\\x7F]|(?:\\x5C[\\x00-\\x7F]))*\\x22)))*@(?:(?:(?!.*[^.]{124,})(?:(?:(?:xn--)?[a-z0-9]+(?:-+[a-z0-9]+)*\\.){1,126}){1,}(?:(?:[a-z][a-z0-9]*)|(?:(?:xn--)[a-z0-9]+))(?:-+[a-z0-9]+)*)|(?:\\[(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){7})|(?:(?!(?:.*[a-f0-9][:\\]]){7,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,5})?)))|(?:(?:IPv6:(?:(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){5}:)|(?:(?!(?:.*[a-f0-9]:){5,})(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3})?::(?:[a-f0-9]{1,4}(?::[a-f0-9]{1,4}){0,3}:)?)))?(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))(?:\\.(?:(?:25[0-5])|(?:2[0-4][0-9])|(?:1[0-9]{2})|(?:[1-9]?[0-9]))){3}))\\]))$/i";
+
+		$res = preg_match( $regex, $returnPath );
+
+		return !!$res;
+	}
+
     /**
      * Sets the property $name to $value.
      *
@@ -182,7 +191,7 @@ class ezcMail extends ezcMailPart
                 {
                     throw new ezcBaseValueException( $name, $value, 'ezcMailAddress or null' );
                 }
-                if ( $value !== null && !filter_var( $value->email, FILTER_VALIDATE_EMAIL ) )
+                if ( $value !== null && !$this->validateReturnPath( $value->email ) )
                 {
                     throw new ezcBaseValueException( $name, $value->email, 'a valid email address or null' );
                 }

--- a/tests/mail_test.php
+++ b/tests/mail_test.php
@@ -507,6 +507,13 @@ class ezcMailTest extends ezcTestCase
         $this->assertNull( $mail->returnPath );
     }
 
+    public function testLongReturnPath()
+    {
+        $mail = new ezcMail();
+        $mail->returnPath = new ezcMailAddress( "SRS0=z9mA=EY=donate-long-name.example.org=b.51907682.51575594.57daed525aaca713@example.org" );
+        $this->assertEquals( "SRS0=z9mA=EY=donate-long-name.example.org=b.51907682.51575594.57daed525aaca713@example.org", $mail->returnPath->email );
+    }
+
     public function testSingleQuoteReturnPath()
     {
         $mail = new ezcMail();


### PR DESCRIPTION
RFC 2821 states that the local part may only be 64 characters, but with SRS this often gets violated.

This patch takes PHP's `filter_var()` email validation regular expression, and extends the allowed length from 64 to 124 for the local part, but only for Return-Path headers.