### PR TITLE
define $connection property to avoid deprecation notice

### DIFF
--- a/src/transports/imap/imap_set.php
+++ b/src/transports/imap/imap_set.php
@@ -116,6 +116,13 @@ class ezcMailImapSet implements ezcMailParserSet
     private $bytesToRead = false;
 
     /**
+     * Holds the connection to the IMAP server.
+     *
+     * @var ezcMailTransportConnection
+     */
+    private $connection = null;
+
+    /**
      * Constructs a new IMAP parser set that will fetch the messages $messages.
      *
      * $connection must hold a valid connection to a IMAP server that is ready

--- a/src/transports/pop3/pop3_set.php
+++ b/src/transports/pop3/pop3_set.php
@@ -75,6 +75,13 @@ class ezcMailPop3Set implements ezcMailParserSet
     private $deleteFromServer = false;
 
     /**
+     * Holds the connection to the POP3 server.
+     *
+     * @var ezcMailTransportConnection
+     */
+    private $connection = null;
+
+    /**
      * Constructs a new POP3 parser set that will fetch the messages $messages.
      *
      * $connection must hold a valid connection to a POP3 server that is ready


### PR DESCRIPTION
Without this fix, I see errors like the following:

[PHP Deprecation] Creation of dynamic property
ezcMailImapSet::$connection is deprecated at
/var/www/powerbase/sites/all/modules/civicrm/vendor/zetacomponents/mail/src/transports/imap/imap_set.php:150