### PR TITLE
Php 8.4 fixes to type hinting

### DIFF
--- a/src/composer.php
+++ b/src/composer.php
@@ -166,9 +166,9 @@ class ezcMailComposer extends ezcMail
     /**
      * Constructs an empty ezcMailComposer object.
      *
-     * @param ezcMailComposerOptions $options
+     * @param ezcMailComposerOptions|null $options
      */
-    public function __construct( ezcMailComposerOptions $options = null )
+    public function __construct( ?ezcMailComposerOptions $options = null )
     {
         $this->properties['plainText'] = null;
         $this->properties['htmlText'] = null;

--- a/src/mail.php
+++ b/src/mail.php
@@ -145,7 +145,7 @@ class ezcMail extends ezcMailPart
     /**
      * Constructs an empty ezcMail object.
      */
-    public function __construct( ezcMailOptions $options = null )
+    public function __construct( ?ezcMailOptions $options = null )
     {
         parent::__construct();
 

--- a/src/parser/rfc2231_implementation.php
+++ b/src/parser/rfc2231_implementation.php
@@ -137,10 +137,10 @@ class ezcMailRfc2231Implementation
      * will not clear out any old values in the object.
      *
      * @param string $header
-     * @param ezcMailContentDispositionHeader $cd
+     * @param ezcMailContentDispositionHeader|null $cd
      * @return ezcMailContentDispositionHeader
      */
-    public static function parseContentDisposition( $header, ezcMailContentDispositionHeader $cd = null )
+    public static function parseContentDisposition( $header, ?ezcMailContentDispositionHeader $cd = null )
     {
         if ( $cd === null )
         {

--- a/src/transports/transport_connection.php
+++ b/src/transports/transport_connection.php
@@ -75,9 +75,9 @@ class ezcMailTransportConnection
      *         if $options contains a property with a value not allowed
      * @param string $server
      * @param int $port
-     * @param ezcMailTransportOptions $options
+     * @param ezcMailTransportOptions|null $options
      */
-    public function __construct( $server, $port, ezcMailTransportOptions $options = null )
+    public function __construct( $server, $port, ?ezcMailTransportOptions $options = null )
     {
         $errno = null;
         $errstr = null;


### PR DESCRIPTION
Addresses issues like

ezcMail::__construct(): Implicitly marking parameter $options as nullable is deprecated, the explicit nullable type must be used instead

- can you tag a release once merged?