### PR TITLE
Ensure headers are strings, not NULL if not set

### DIFF
--- a/src/parser/interfaces/part_parser.php
+++ b/src/parser/interfaces/part_parser.php
@@ -168,7 +168,11 @@ abstract class ezcMailPartParser
                 break;
 
             case 'text':
-                if ( ezcMailPartParser::$parseTextAttachmentsAsFiles === true )
+                if ( (ezcMailPartParser::$parseTextAttachmentsAsFiles === true) &&
+                     (preg_match('/\s*filename="?([^;"]*);?/i', $headers['Content-Disposition'] ?? '') ||
+                      preg_match( '/\s*name="?([^;"]*);?/i', $headers['Content-Type'] ?? '')
+                     )
+                   )
                 {
                     $bodyParser = new ezcMailFileParser( $mainType, $subType, $headers );
                 }


### PR DESCRIPTION
This is a patch we have been carrying for a while - in our tests we have some examples of emails where these headers are not set and the attached file is (e.g. an .ics). I *think* that is possible for real emails. This was our original issue https://lab.civicrm.org/dev/core/-/issues/940


